### PR TITLE
Develop

### DIFF
--- a/testing/bit_packing.cpp
+++ b/testing/bit_packing.cpp
@@ -146,37 +146,37 @@ TEST(BitPacking, GetBit) {
     uint8_t byte = 0x5a; // 0x01011010
 
     // Set a single byte.
-    ASSERT_EQ(false, xyuv::get_bit(&byte, 0));
-    ASSERT_EQ(true,  xyuv::get_bit(&byte, 1));
-    ASSERT_EQ(false, xyuv::get_bit(&byte, 2));
-    ASSERT_EQ(true,  xyuv::get_bit(&byte, 3));
-    ASSERT_EQ(true,  xyuv::get_bit(&byte, 4));
-    ASSERT_EQ(false, xyuv::get_bit(&byte, 5));
-    ASSERT_EQ(true,  xyuv::get_bit(&byte, 6));
-    ASSERT_EQ(false, xyuv::get_bit(&byte, 7));
+    ASSERT_FALSE(xyuv::get_bit(&byte, 0));
+    ASSERT_TRUE (xyuv::get_bit(&byte, 1));
+    ASSERT_FALSE(xyuv::get_bit(&byte, 2));
+    ASSERT_TRUE (xyuv::get_bit(&byte, 3));
+    ASSERT_TRUE (xyuv::get_bit(&byte, 4));
+    ASSERT_FALSE(xyuv::get_bit(&byte, 5));
+    ASSERT_TRUE (xyuv::get_bit(&byte, 6));
+    ASSERT_FALSE(xyuv::get_bit(&byte, 7));
 }
 
 TEST(BitPacking, GetBitMultibyte) {        // <-- Increasing Byte addr  <--
     const uint8_t bytes[2] = {0x5a, 0xdc}; // 0b 11011100 01011010
 
     // Set a single byte.
-    ASSERT_EQ(false, xyuv::get_bit(bytes, 0));
-    ASSERT_EQ(true,  xyuv::get_bit(bytes, 1));
-    ASSERT_EQ(false, xyuv::get_bit(bytes, 2));
-    ASSERT_EQ(true,  xyuv::get_bit(bytes, 3));
-    ASSERT_EQ(true,  xyuv::get_bit(bytes, 4));
-    ASSERT_EQ(false, xyuv::get_bit(bytes, 5));
-    ASSERT_EQ(true,  xyuv::get_bit(bytes, 6));
-    ASSERT_EQ(false, xyuv::get_bit(bytes, 7));
+    ASSERT_FALSE(xyuv::get_bit(bytes, 0));
+    ASSERT_TRUE (xyuv::get_bit(bytes, 1));
+    ASSERT_FALSE(xyuv::get_bit(bytes, 2));
+    ASSERT_TRUE (xyuv::get_bit(bytes, 3));
+    ASSERT_TRUE (xyuv::get_bit(bytes, 4));
+    ASSERT_FALSE(xyuv::get_bit(bytes, 5));
+    ASSERT_TRUE (xyuv::get_bit(bytes, 6));
+    ASSERT_FALSE(xyuv::get_bit(bytes, 7));
 
-    ASSERT_EQ(false, xyuv::get_bit(bytes, 8 ));
-    ASSERT_EQ(false, xyuv::get_bit(bytes, 9 ));
-    ASSERT_EQ(true,  xyuv::get_bit(bytes, 10));
-    ASSERT_EQ(true,  xyuv::get_bit(bytes, 11));
-    ASSERT_EQ(true,  xyuv::get_bit(bytes, 12));
-    ASSERT_EQ(false, xyuv::get_bit(bytes, 13));
-    ASSERT_EQ(true,  xyuv::get_bit(bytes, 14));
-    ASSERT_EQ(true,  xyuv::get_bit(bytes, 15));
+    ASSERT_FALSE(xyuv::get_bit(bytes, 8 ));
+    ASSERT_FALSE(xyuv::get_bit(bytes, 9 ));
+    ASSERT_TRUE (xyuv::get_bit(bytes, 10));
+    ASSERT_TRUE (xyuv::get_bit(bytes, 11));
+    ASSERT_TRUE (xyuv::get_bit(bytes, 12));
+    ASSERT_FALSE(xyuv::get_bit(bytes, 13));
+    ASSERT_TRUE (xyuv::get_bit(bytes, 14));
+    ASSERT_TRUE (xyuv::get_bit(bytes, 15));
 }
 
 TEST(BitPacking, ReadSinglebyte)
@@ -204,7 +204,7 @@ TEST(BitPacking, ReadSinglebyte)
 
 TEST(BitPacking, ReadMultibyte)
 {                                               // <-- Increasing Byte addr  <--
-    const uint8_t bytes[2] = { 0xdc, 0x5a };    // 0b 01011010 11011100 
+    const uint8_t bytes[2] = { 0xdc, 0x5a };    // 0b 01011010 11011100
     unorm_t result;
 
     // Read all 8 bits from the low byte

--- a/utilities/CMakeLists.txt
+++ b/utilities/CMakeLists.txt
@@ -17,6 +17,10 @@ target_link_libraries(xyuv-header xyuv)
 target_compile_options(xyuv-header
     PUBLIC -std=c++11
 )
+
+target_compile_definitions(xyuv-header
+    PRIVATE INSTALL_FORMATS_PATH="${CMAKE_INSTALL_PREFIX}/share/xyuv")
+
 add_dependencies(xyuv-header xyuv)
 
 # If we have compiled support for ImageMagick also include that.

--- a/utilities/XYUVHeader.h
+++ b/utilities/XYUVHeader.h
@@ -84,11 +84,15 @@ struct options {
     // Display the resulting image.
     bool display = false;
 
+    // Inverts the Y dimension in the resulting image.
+    bool flip_y = false;
+
     // List all loaded formats and quit.
     bool list_all_formats = false;
 
     // Print help and quit. (Superseeds list_all_formats).
     bool print_help = false;
+
 };
 
 class XYUVHeader {

--- a/utilities/xyuv_header_parse_args.cpp
+++ b/utilities/xyuv_header_parse_args.cpp
@@ -123,6 +123,10 @@ void XYUVHeader::PrintHelp() {
                        "\n                 converted back to RGB and saved."
     );
 
+    print_help_section("-y",
+                       "--flip-y",
+                       "Invert the Y dimension in the image, effectively flipping it upside-down."
+    );
 
     print_help_section("-c",
                        "--cat",
@@ -243,12 +247,13 @@ static ::options::output_modes interpret_output_mode(const std::string &optarg) 
             { "display", no_argument, 0, 'd'},
             { "no-writeout", no_argument, 0, 'n'},
             { "list", no_argument, 0, 'l'},
+            { "flip-y", no_argument, 0, 'y'},
             { "help", no_argument, 0, '?'},
             {}
     };
     int index = 0;
     int c = -1;
-    const char * const shortopts = "?lndcF:o:f:h:w:m:s:";
+    const char * const shortopts = "?lndcyF:o:f:h:w:m:s:";
 
     ::options options;
     while ( (c = getopt_long(argc, argv, shortopts, long_opts, &index )) != -1 ) {
@@ -273,6 +278,9 @@ static ::options::output_modes interpret_output_mode(const std::string &optarg) 
                 break;
             case 'h':
                 options.image_h = static_cast<uint32_t>(strtoul(optarg, nullptr, 0));
+                break;
+            case 'y':
+                options.flip_y = true;
                 break;
             case 'c':
                 options.concatinate = true;

--- a/utilities/xyuv_header_run.cpp
+++ b/utilities/xyuv_header_run.cpp
@@ -217,6 +217,20 @@ void XYUVHeader::Run(const ::options & options) {
 
         xyuv::frame frame = LoadConvertFrame(target_format, options.input_files[i]);
 
+        // If --flip-y is set then change the image origin to the inverse.
+        if (options.flip_y) {
+            switch (frame.format.origin) {
+                case xyuv::image_origin::UPPER_LEFT:
+                    frame.format.origin = xyuv::image_origin::LOWER_LEFT;
+                    break;
+                case xyuv::image_origin::LOWER_LEFT:
+                    frame.format.origin = xyuv::image_origin::UPPER_LEFT;
+                    break;
+                default:
+                    break;
+            }
+        }
+
         if (options.writeout) {
             if (options.concatinate) {
                 // Append file at end of concatinated string.

--- a/utilities/xyuv_header_run.cpp
+++ b/utilities/xyuv_header_run.cpp
@@ -41,8 +41,14 @@ void XYUVHeader::Run(const ::options & options) {
         PrintHelp();
         return;
     }
+
     // Otherwise do something useful.
-    // First Load all additional formats.
+#ifdef INSTALL_FORMATS_PATH
+    // Load base formats from installation path
+    config_manager_.load_configurations(INSTALL_FORMATS_PATH);
+#endif
+
+    // Load all additional formats supplied on the command line.
     for (const auto & path : options.additional_config_directories) {
         config_manager_.load_configurations(path);
     }

--- a/xyuv/include/xyuv/config_manager.h
+++ b/xyuv/include/xyuv/config_manager.h
@@ -84,7 +84,7 @@ public:
     //! format templates under \a format_search_root /<PX_FMT_DIR>
     //! and conversion matrices under \a format_search_root/<CONVERSION_MATRICES_DIR>. See the source for the default
     //! values for each of these definitions.
-    void load_configurations(const std::string &format_search_root);
+    void load_configurations(std::string format_search_root);
 
     //! \brief Add a configuration with the given key.
     //! \details This will manually add a new format_template/chroma_siting/conversion_matrix to the configuration

--- a/xyuv/src/config-parser/config_manager.cpp
+++ b/xyuv/src/config-parser/config_manager.cpp
@@ -107,8 +107,11 @@ config_manager::config_manager(const std::string &format_search_root) {
     load_configurations(format_search_root);
 }
 
-void config_manager::load_configurations(const std::string &format_search_root) {
-    XYUV_ASSERT(format_search_root.back() == '/' || format_search_root.back() == '\\');
+void config_manager::load_configurations(std::string format_search_root) {
+    if(!(format_search_root.back() == '/' || format_search_root.back() == '\\')) {
+        format_search_root += '/';
+    }
+
     load_format_templates(format_search_root + PX_FMT_DIR);
     load_chroma_sitings(format_search_root + CHROMA_SITING_DIR);
     load_conversion_matrices(format_search_root + CONVERSION_MATRICES_DIR);


### PR DESCRIPTION
Minor fixes and features:
- Fixed compile error in g++ in unit tests.
- Added command line option to flip images directly from xyuv-header
- Format templates at default install location are now loaded by automatically when xyuv-header runs.
