### PR TITLE
Add a workaround for configuring ImageMagick++ from MacPorts.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,13 @@ if(NOT NO_EXTERNAL_IMAGEMAGICK)
         get_filename_component(MAGICK_LIB_DIR ${ImageMagick_MagickCore_LIBRARY} DIRECTORY)
         # Find where Magick++-config lives
         file(GLOB_RECURSE MAGICK_CONFIG FOLLOW_SYMLINKS ${MAGICK_LIB_DIR}/Magick++-config)
+        list(LENGTH MAGICK_CONFIG TEMP)
+        if (${TEMP} EQUAL 0)
+            # We failed to find Magick++-config in the same folder as the library,
+            # MacPorts puts the library in /opt/local/lib, and the binaries directly into
+            # /opt/local/bin
+            file(GLOB_RECURSE MAGICK_CONFIG FOLLOW_SYMLINKS ${MAGICK_LIB_DIR}/../bin/Magick++-config)
+        endif (${TEMP} EQUAL 0)
         # Ask about CXX and lib flags/locations
         set(MAGICK_CONFIG ${MAGICK_CONFIG} CACHE string "Path to Magick++-config utility")
         execute_process(COMMAND "${MAGICK_CONFIG}" "--cxxflags" OUTPUT_VARIABLE MAGICK_CXX_FLAGS)


### PR DESCRIPTION
This might not be the best solution to the problem, as there might be potentially a fair amount of folders to recurse through when solving it this way.

The problem is basically that with MacPorts, there is no separate folder where ImageMagick's files reside, instead they are divided between /opt/local/bin and /opt/local/lib...

Other options include using "find_program", to locate Magick++-config (which seems to be in path when using MacPorts (as suggested here: http://stackoverflow.com/questions/37759833/about-magick-how-to-write-the-cmakelists)

Or using pkg-config to grab the config info, as suggested in this Debian bug-report from 2015:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=776832;msg=5

Perhaps the pkg-config option is the safest of these, but whether any of them are completely compatible with the intended "multiple installations of ImageMagick with different build-options"-scenario that MagickConfig is intended to solve... well I don't really know.
