### PR TITLE
Various fixes reported by Xcode's static-analyzer (presumably clang's static analyzer)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,13 @@ if(NOT NO_EXTERNAL_IMAGEMAGICK)
         get_filename_component(MAGICK_LIB_DIR ${ImageMagick_MagickCore_LIBRARY} DIRECTORY)
         # Find where Magick++-config lives
         file(GLOB_RECURSE MAGICK_CONFIG FOLLOW_SYMLINKS ${MAGICK_LIB_DIR}/Magick++-config)
+        list(LENGTH MAGICK_CONFIG TEMP)
+        if (${TEMP} EQUAL 0)
+            # We failed to find Magick++-config in the same folder as the library,
+            # MacPorts puts the library in /opt/local/lib, and the binaries directly into
+            # /opt/local/bin
+            file(GLOB_RECURSE MAGICK_CONFIG FOLLOW_SYMLINKS ${MAGICK_LIB_DIR}/../bin/Magick++-config)
+        endif (${TEMP} EQUAL 0)
         # Ask about CXX and lib flags/locations
         set(MAGICK_CONFIG ${MAGICK_CONFIG} CACHE string "Path to Magick++-config utility")
         execute_process(COMMAND "${MAGICK_CONFIG}" "--cxxflags" OUTPUT_VARIABLE MAGICK_CXX_FLAGS)

--- a/xyuv/src/block_reorder.cpp
+++ b/xyuv/src/block_reorder.cpp
@@ -105,7 +105,7 @@ namespace xyuv {
         uint32_t height_in_possible_blocks_lines = static_cast<uint32_t>(plane.size / plane.line_stride);
         uint32_t height_in_macro_blocks = height_in_possible_blocks_lines / plane.block_order.mega_block_height;
 
-        std::unique_ptr<uint8_t> temp_plane {new uint8_t[plane.size]};
+        std::unique_ptr<uint8_t[]> temp_plane {new uint8_t[plane.size]};
 
         for (uint32_t block_y = 0; block_y < height_in_macro_blocks; block_y++) {
             for (uint32_t block_x = 0; block_x < width_in_macro_blocks; block_x++) {
@@ -151,7 +151,7 @@ namespace xyuv {
         uint32_t height_in_possible_blocks_lines = static_cast<uint32_t>(plane.size / plane.line_stride);
         uint32_t height_in_macro_blocks = height_in_possible_blocks_lines / plane.block_order.mega_block_height;
 
-        std::unique_ptr<uint8_t> temp_plane { new uint8_t[plane.size] };
+        std::unique_ptr<uint8_t[]> temp_plane { new uint8_t[plane.size] };
 
         for (uint32_t block_y = 0; block_y < height_in_macro_blocks; block_y++) {
             for (uint32_t block_x = 0; block_x < width_in_macro_blocks; block_x++) {

--- a/xyuv/src/block_reorder.cpp
+++ b/xyuv/src/block_reorder.cpp
@@ -39,7 +39,7 @@ static inline void copy_bits(uint8_t * dst_base, uint32_t dst_bit_offset, const 
 namespace xyuv {
 
     // Calculate the position of this block.
-    inline uint32_t get_block_order_offset(uint32_t block_x, uint32_t block_y, const ::block_order & block_order) {
+    inline uint32_t _get_block_order_offset(uint32_t block_x, uint32_t block_y, const ::block_order & block_order) {
         uint32_t xval = 0;
         uint32_t yval = 0;
         for (uint32_t i = 0; i < 32; ++i) {
@@ -57,10 +57,13 @@ namespace xyuv {
         return offset;
     }
 
+	uint32_t get_block_order_offset(uint32_t block_x, uint32_t block_y, const ::block_order & block_order) {
+		return _get_block_order_offset(block_x, block_y, block_order);
+	}
 
     inline std::pair<uint32_t,uint32_t> _get_block_order_coords(uint32_t block_x, uint32_t block_y, const ::block_order & block_order) {
 
-        uint32_t  offset = get_block_order_offset(block_x, block_y, block_order);
+        uint32_t offset = _get_block_order_offset(block_x, block_y, block_order);
 
         auto p = std::make_pair(offset % block_order.mega_block_width, offset / block_order.mega_block_width);
         return p;

--- a/xyuv/src/config-parser/parse_helpers.cpp
+++ b/xyuv/src/config-parser/parse_helpers.cpp
@@ -24,6 +24,7 @@
 
 #include "../assert.h"
 #include "parsing_helpers.h"
+#include <string>
 
 namespace xyuv {
 

--- a/xyuv/src/external/libpng_wrapper.cpp
+++ b/xyuv/src/external/libpng_wrapper.cpp
@@ -500,11 +500,11 @@ namespace xyuv {
 
 
     uint32_t libpng_wrapper::rows() const {
-        return data ? 0 : static_cast<uint32_t >(this->data->height);
+        return data ? static_cast<uint32_t >(this->data->height) : 0;
     }
 
     uint32_t libpng_wrapper::columns() const {
-        return data ? 0 : static_cast<uint32_t >(this->data->width);
+        return data ? static_cast<uint32_t >(this->data->width) : 0;
     }
 
 

--- a/xyuv/src/external/libpng_wrapper.cpp
+++ b/xyuv/src/external/libpng_wrapper.cpp
@@ -292,7 +292,7 @@ namespace xyuv {
                                                  const xyuv::conversion_matrix &conversion_matrix) {
         // Check if we need to reallocate image.
         if (this->data == nullptr || !(yuv_image_444.image_h <= this->data->height && yuv_image_444.image_w <= this->data->width)) {
-            *this = std::move(libpng_wrapper(yuv_image_444.image_w, yuv_image_444.image_h, (this->data && this->data->bit_depth == 16) ? BITS_16 : BITS_8));
+            *this = libpng_wrapper(yuv_image_444.image_w, yuv_image_444.image_h, (this->data && this->data->bit_depth == 16) ? BITS_16 : BITS_8);
         } else {
             // Overwrite width + height for the case where we have not reallocated.
             this->data->width = yuv_image_444.image_w;

--- a/xyuv/src/format.cpp
+++ b/xyuv/src/format.cpp
@@ -131,18 +131,16 @@ xyuv::frame create_frame(
         const uint8_t *raw_data,
         uint64_t raw_data_size
 ) {
-    // First, allocate the buffer.
-    std::unique_ptr<uint8_t[]> data(new uint8_t[format.size]);
+    xyuv::frame frame;
+    frame.format = format;
+
+	// First, allocate the buffer.
+	frame.data.reset(new uint8_t[format.size]);
 
     // If raw_data has been supplied. Copy it.
     if (raw_data != nullptr) {
-        memmove(data.get(), raw_data, std::min(format.size, raw_data_size));
+        memmove(frame.data.get(), raw_data, std::min(format.size, raw_data_size));
     }
-
-    // Assign and return.
-    xyuv::frame frame;
-    frame.format = format;
-    frame.data = std::move(data);
 
     return frame;
 };

--- a/xyuv/src/pixel_packer.cpp
+++ b/xyuv/src/pixel_packer.cpp
@@ -463,7 +463,7 @@ yuv_image decode_frame(const xyuv::frame &frame_in) {
 
     const uint8_t * raw_data = frame_in.data.get();
 
-    std::unique_ptr<uint8_t> tmp_buffer;
+    std::unique_ptr<uint8_t[]> tmp_buffer;
     if (needs_reorder(frame_in.format)) {
         // Todo: If needed optimize this for memory.
         // At some point we will have allocated 2x frame + 1 plane.


### PR DESCRIPTION
- A few cases of std::unique_ptr being used without T[] explicitly typed, leading to delete instead of delete[]
- 2 ternary operators were the wrong way around, leading to exactly the nullptr dereferences they were meant to protect against.
- Somehow the analyzer warns about a std::move between two std::unique_ptr's, since it was a trivial fix to make it stop complaining, I added it.

Additionally the profiler build was blocked by these issues:
- Some odd include issue made std::string not have a subscript operator.
- Another inline function was used outside of the file it was declared in, which works in GCC, but not Clang.

This PR depends on the preceeding fixes I posted, hence those patches are visible in this PR too.
